### PR TITLE
Add default value to Media::$sortedMetadatas

### DIFF
--- a/Entity/Media.php
+++ b/Entity/Media.php
@@ -69,7 +69,7 @@ class Media
      *
      * @var array
      */
-    private $sortedMetadatas;
+    private $sortedMetadatas = array();
 
     /**
      * @var \DateTime $createdAt


### PR DESCRIPTION
Since PHP 7.2, calling count on null raise a warning

https://3v4l.org/Efkoc
